### PR TITLE
Feature/improve options parser

### DIFF
--- a/lib/em-hiredis-sentinel/redis_client.rb
+++ b/lib/em-hiredis-sentinel/redis_client.rb
@@ -338,10 +338,9 @@ module EventMachine::Hiredis::Sentinel
             o = o.prepend('redis://') if !o.include? '://'
             o = URI.parse(o)
         end
-
-        ret << { :host => o.host, :port => o.port || 26379 }
+        ret << { :host => o[:host], :port => o[:port] || 26379 } if o.is_a?(Hash) && o.key?(:host)
+        ret << { :host => o.host, :port => o.port || 26379 } if o.is_a?(URI)
       end
-
       ret
     end
   end


### PR DESCRIPTION
Dear Justin
I wonder if you still accept pull requests.
Recently I figured out that  when I try to initialize my sentinels with Hash like that: 
{host:'sentinel3.example.net'},
{host:'sentinel4.example.net', port:26380},
I get the error
<b>in 'block in _parse_sentinel_options': undefined method 'host' for {:host=>"sentinel3.example.net"}:Hash (NoMethodError)</b>

Which happens because _parse_sentinel_options method can't really handle hashes. 

``` rb
ret << { :host => o.host, :port => o.port || 26379 }
```

So I created a pull request that solves described issue. It would be wonderful if you consider it.

Sincerely yours,
Maksim
